### PR TITLE
Use checkout -f to ignore unmerged leftovers

### DIFF
--- a/merge.py
+++ b/merge.py
@@ -164,7 +164,7 @@ class Merge(BotPlugin):  # pylint:disable=too-many-ancestors
         """
         for argv in [
                 ['fetch', '-p'],
-                ['checkout', '-B', 'develop', 'origin/develop'],
+                ['checkout', '-f', '-B', 'develop', 'origin/develop'],
                 [
                     'merge', '--no-ff',
                     '-m', 'Merge {} to develop'.format(branch_name),


### PR DESCRIPTION
Ignore unmerged files from previous failed merge when checking out develop.
If a merge failed it means we didn't delete the original branch yet
and can safely ignore the unmerged stuff (we can always just merge it
again after applying required fixes).